### PR TITLE
fix: update link component to use navigateTo directly and support open in new tab

### DIFF
--- a/ui/extensions/hello/src/components/link.js
+++ b/ui/extensions/hello/src/components/link.js
@@ -1,18 +1,33 @@
 import React, { useContext } from "react";
-import {  Link as ReactRouterLink } from "react-router-dom";
+import { Link as ReactRouterLink } from "react-router-dom";
 import { FalconApiContext } from "../contexts/falcon-api-context.js";
 
-function Link({ children, useFalconNavigation = false, to }) {
-  const { navigation } = useContext(FalconApiContext);
+function Link({
+  children,
+  useFalconNavigation = false,
+  to,
+  openInNewTab = false,
+}) {
+  const { falcon, navigation } = useContext(FalconApiContext);
+  const absolutePath = falcon.bridge.targetOrigin.concat(to);
 
+  const onClick = (e) => {
+    e.preventDefault();
+    navigation?.navigateTo({
+      path: to,
+      type: "falcon",
+      target: openInNewTab ? "_blank" : "_self",
+    });
+  };
   if (useFalconNavigation) {
     return (
-      <a onClick={navigation.onClick} href={to}>{children}</a>
-    )
+      <a onClick={onClick} href={absolutePath}>
+        {children}
+      </a>
+    );
   }
 
-  return <ReactRouterLink to={to}>{children}</ReactRouterLink>
-   
+  return <ReactRouterLink to={to}>{children}</ReactRouterLink>;
 }
 
 export { Link };

--- a/ui/extensions/hello/src/dist/app.js
+++ b/ui/extensions/hello/src/dist/app.js
@@ -5335,15 +5335,26 @@ function requireReactDom () {
 function Link({
   children,
   useFalconNavigation = false,
-  to
+  to,
+  openInNewTab = false
 }) {
   const {
+    falcon,
     navigation
   } = reactExports.useContext(FalconApiContext);
+  const absolutePath = falcon.bridge.targetOrigin.concat(to);
+  const onClick = e => {
+    e.preventDefault();
+    navigation?.navigateTo({
+      path: to,
+      type: "falcon",
+      target: openInNewTab ? "_blank" : "_self"
+    });
+  };
   if (useFalconNavigation) {
     return /*#__PURE__*/React.createElement("a", {
-      onClick: navigation.onClick,
-      href: to
+      onClick: onClick,
+      href: absolutePath
     }, children);
   }
   return /*#__PURE__*/React.createElement(Link$1, {


### PR DESCRIPTION
This PR updates the Link component to use `navigateTo` directly.  It also uses an absolute url for the link's `href` which allows users to right click the link and open it in a new tab directly