### PR TITLE
Upgrade FDK to 1.1.2

### DIFF
--- a/functions/hello/requirements.txt
+++ b/functions/hello/requirements.txt
@@ -1,1 +1,1 @@
-crowdstrike-foundry-function==1.1.1
+crowdstrike-foundry-function==1.1.2

--- a/functions/host-details/requirements.txt
+++ b/functions/host-details/requirements.txt
@@ -1,2 +1,2 @@
-crowdstrike-foundry-function==1.1.1
+crowdstrike-foundry-function==1.1.2
 crowdstrike-falconpy

--- a/functions/host-info/requirements.txt
+++ b/functions/host-info/requirements.txt
@@ -1,1 +1,1 @@
-crowdstrike-foundry-function==1.1.1
+crowdstrike-foundry-function==1.1.2

--- a/functions/log-event/requirements.txt
+++ b/functions/log-event/requirements.txt
@@ -1,2 +1,2 @@
-crowdstrike-foundry-function==1.1.1
+crowdstrike-foundry-function==1.1.2
 crowdstrike-falconpy

--- a/functions/servicenow/requirements.txt
+++ b/functions/servicenow/requirements.txt
@@ -1,2 +1,2 @@
-crowdstrike-foundry-function==1.1.1
+crowdstrike-foundry-function==1.1.2
 crowdstrike-falconpy

--- a/functions/user-management/requirements.txt
+++ b/functions/user-management/requirements.txt
@@ -1,1 +1,1 @@
-crowdstrike-foundry-function==1.1.1
+crowdstrike-foundry-function==1.1.2


### PR DESCRIPTION
Upgrades crowdstrike-foundry-function from 1.1.1 to 1.1.2 to address urllib3 security vulnerability CVE-2025-50181 (moderate severity, CVSS 5.3).

This vulnerability involves a redirect bypass that could lead to SSRF protection bypass.

**Changes:**
- Updated crowdstrike-foundry-function to 1.1.2 in all function requirements.txt files

**References:**
- CVE-2025-50181: https://nvd.nist.gov/vuln/detail/CVE-2025-50181
- FDK Release: https://github.com/CrowdStrike/foundry-fn-python/releases/tag/1.1.2
- Fixes #58