### PR TITLE
Remove hardcoded workers and increase CI retries

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -10,8 +10,7 @@ export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 1 : 0, 
-  workers: process.env.CI ? 1 : 4,
+  retries: process.env.CI ? 2 : 0, 
   timeout: process.env.CI ? 60 * 1000 : 45 * 1000, 
   expect: {
     timeout: process.env.CI ? 10 * 1000 : 8 * 1000,


### PR DESCRIPTION
Removes the hardcoded `workers: 1` in CI, letting Playwright use its default (50% of available CPUs) for faster test runs. Also increases CI retries from 1 to 2 (3 total attempts) as a safety net for intermittent UI timing issues.