### PR TITLE
Fix iframe selector for Charlotte AI compatibility

### DIFF
--- a/e2e/src/pages/HelloExtensionPage.ts
+++ b/e2e/src/pages/HelloExtensionPage.ts
@@ -58,11 +58,11 @@ export class HelloExtensionPage extends SocketNavigationPage {
         }
 
         // Verify iframe loads
-        await expect(this.page.locator('iframe')).toBeVisible({ timeout: 15000 });
+        await expect(this.page.locator('iframe[name="portal"]')).toBeVisible({ timeout: 15000 });
         this.logger.info('Extension iframe loaded');
 
         // Verify iframe content
-        const iframe: FrameLocator = this.page.frameLocator('iframe');
+        const iframe: FrameLocator = this.page.frameLocator('iframe[name="portal"]');
 
         // Check for "Foundry Functions Demo" text
         await expect(iframe.getByText(/Foundry Functions Demo/i)).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
Charlotte AI now adds a second iframe to Falcon console pages, causing Playwright's strict mode to fail with `locator('iframe') resolved to 2 elements`. This targets the Foundry app extension iframe specifically using `iframe[name="portal"]`.

Validated locally: all 8 e2e tests pass.