### PR TITLE
Fix parameter alignment in CustomStorage method calls

### DIFF
--- a/functions/log-event/main.py
+++ b/functions/log-event/main.py
@@ -52,8 +52,8 @@ def on_post(request: Request) -> Response:
         collection_name = "event_logs"
 
         response = custom_storage.PutObject(body=json_data,
-                                        collection_name=collection_name,
-                                        object_key=event_id)
+                                            collection_name=collection_name,
+                                            object_key=event_id)
 
         if response["status_code"] != 200:
             error_message = response.get("error", {}).get("message", "Unknown error")
@@ -67,8 +67,8 @@ def on_post(request: Request) -> Response:
 
         # Query the collection to retrieve the event by id
         query_response = custom_storage.SearchObjects(filter=f"event_id:'{event_id}'",
-                                                  collection_name=collection_name,
-                                                  limit=5)
+                                                      collection_name=collection_name,
+                                                      limit=5)
 
         return Response(
             body={


### PR DESCRIPTION
Align continuation parameters under the opening parenthesis of PutObject and SearchObjects calls in log-event/main.py. The alignment was off by 4 spaces after the APIHarnessV2 to CustomStorage migration.