### PR TITLE
Upgrade @crowdstrike/foundry-playwright to 0.5.3

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@crowdstrike/foundry-playwright": "0.5.1",
+        "@crowdstrike/foundry-playwright": "0.5.3",
         "@types/node": "25.6.0"
       },
       "engines": {
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@crowdstrike/foundry-playwright": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-playwright/-/foundry-playwright-0.5.1.tgz",
-      "integrity": "sha512-aB74uvvvfrOkHvy3jVfpeO3JPOjPdNHuMR+bUZyqUknFtZ4jBtquQMGWumspbXS+P78vDuI8c8BTVilnI2sscA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-playwright/-/foundry-playwright-0.5.3.tgz",
+      "integrity": "sha512-sB0Oz0MkgO4bOxbjx0FpQDAsQwTMCP4ndSjdrXViiFPKjLpmbAFKgY5A/D47GhTxYcBJQ3XxNryu7gcwEYDwSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -15,7 +15,7 @@
     "node": ">=22.0.0"
   },
   "devDependencies": {
-    "@crowdstrike/foundry-playwright": "0.5.1",
+    "@crowdstrike/foundry-playwright": "0.5.3",
     "@types/node": "25.6.0"
   }
 }


### PR DESCRIPTION
Upgrades the e2e test dependency from 0.5.1 to 0.5.3.

0.5.3 makes the extension expand timeout configurable (default 30s in CI, up from a hardcoded 10s). In CI the detection details panel renders the extension accordion button in just over 10s, so the Hello UI extension test was timing out on the first attempt and only passing on retry, surfacing as flaky. The new default gives it room to pass on the first attempt.

This release also includes the 0.5.2 AppBuilderPage deploy/release dialog fixes for slower CI environments.

No test code changes are needed — the fix lives entirely in the library.