### PR TITLE
Upgrade @crowdstrike/foundry-js to 0.22.0, fix tmp and ws CVEs

### DIFF
--- a/ui/extensions/hello/package-lock.json
+++ b/ui/extensions/hello/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@crowdstrike/falcon-shoelace": "0.4.0",
-        "@crowdstrike/foundry-js": "0.21.0",
+        "@crowdstrike/foundry-js": "0.22.0",
         "@crowdstrike/tailwind-toucan-base": "5.0.0",
         "@shoelace-style/shoelace": "2.20.1",
         "react": "19.2.1",
@@ -1935,14 +1935,14 @@
       "license": "MIT"
     },
     "node_modules/@crowdstrike/foundry-js": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-js/-/foundry-js-0.21.0.tgz",
-      "integrity": "sha512-anhEJJQXSGnpwOMhyYquXyLRQx1OdsqZ205xewLt3LUccz6hZpAJRFs6M+u/y4xzV8xXQ0+Y0Swz/JbHXXYLdQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-js/-/foundry-js-0.22.0.tgz",
+      "integrity": "sha512-L0ztqCCG/Xg00or5mWz0LU26TRCSPD3LofNwx3WIh7njICFk/LK2vpb38WbyM6YHuyVgWly73a2M7+TFDXKa/g==",
       "license": "MIT",
       "dependencies": {
         "emittery": "1.2.0",
         "typescript-memoize": "1.1.1",
-        "uuid": "13.0.0"
+        "uuid": "13.0.1"
       },
       "engines": {
         "node": ">=22"
@@ -10130,9 +10130,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -10571,9 +10571,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/ui/extensions/hello/package.json
+++ b/ui/extensions/hello/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@crowdstrike/falcon-shoelace": "0.4.0",
-    "@crowdstrike/foundry-js": "0.21.0",
+    "@crowdstrike/foundry-js": "0.22.0",
     "@crowdstrike/tailwind-toucan-base": "5.0.0",
     "@shoelace-style/shoelace": "2.20.1",
     "react": "19.2.1",
@@ -77,6 +77,8 @@
     "yaml@1": "1.10.3",
     "brace-expansion@1": "1.1.13",
     "brace-expansion@2": "2.0.3",
-    "uuid": "13.0.1"
+    "uuid": "13.0.1",
+    "tmp": "0.2.7",
+    "ws": "8.21.0"
   }
 }


### PR DESCRIPTION
- @crowdstrike/foundry-js 0.21.0 → 0.22.0 (latest)
- Added tmp and ws overrides to fix high-severity path traversal and moderate memory disclosure CVEs
- 0 vulnerabilities remaining, all 23 tests passing